### PR TITLE
Feature/jwt

### DIFF
--- a/ormconfig.ts
+++ b/ormconfig.ts
@@ -19,7 +19,7 @@ const ormconfig: TypeOrmModuleOptions = {
   autoLoadEntities: true,
   timezone: 'Z',
   charset: 'utf8mb4',
-  synchronize: true,
+  synchronize: false,
   logging: true,
 };
 

--- a/src/auth/auth.docs.ts
+++ b/src/auth/auth.docs.ts
@@ -81,7 +81,7 @@ export const docs: SwaggerMethodDoc<AuthController> = {
       ApiResponse({
         status: 401,
         description:
-          '1. Refresh Token 전송이 안 되었습니다.\t\n 2. 유효하지 않은 토큰입니다. \t\n 3. 토큰이 만료되었습니다. \t\n 4. 유효하지 않은 토큰입니다.',
+          '1. 리프레시 토큰이 전송되지 않았습니다. \t\n 2. 유효하지 않은 토큰입니다. \t\n 3. 토큰이 만료되었습니다.',
       }),
       ApiResponse({status: 403, description: '해당 요청의 권한이 없습니다'}),
       ApiResponse({status: 500, description: '예기치 못한 못한 서버에러가 발생했습니다.'}),
@@ -101,7 +101,7 @@ export const docs: SwaggerMethodDoc<AuthController> = {
       ApiResponse({
         status: 401,
         description:
-          '1. Refresh Token 전송이 안 되었습니다.\t\n 2. 유효하지 않은 토큰입니다. \t\n 3. 토큰이 만료되었습니다. \t\n 4. 유효하지 않은 토큰입니다.',
+          '1. 리프레시 토큰이 전송되지 않았습니다. \t\n 2. 유효하지 않은 토큰입니다. \t\n 3. 토큰이 만료되었습니다.',
       }),
       ApiResponse({status: 403, description: '해당 요청의 권한이 없습니다'}),
       ApiResponse({status: 405, description: '토큰 만료 2주 전부터 갱신이 가능합니다.'}),

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -11,6 +11,7 @@ import {JwtModule} from '@nestjs/jwt';
 import {LocalStrategy} from './strategy/local.strategy';
 import {JwtStrategy} from './strategy/jwt.strategy';
 import {User} from './../user/entities/user.entity';
+import {JwtRefreshStrategy} from './strategy/jwt-refresh.strategy';
 
 @Module({
   imports: [
@@ -30,7 +31,7 @@ import {User} from './../user/entities/user.entity';
     }),
   ],
   controllers: [AuthController],
-  providers: [AuthService, MailSender, LocalStrategy, JwtStrategy],
+  providers: [AuthService, MailSender, LocalStrategy, JwtStrategy, JwtRefreshStrategy],
   exports: [AuthService],
 })
 export class AuthModule {}

--- a/src/auth/guard/jwt-auth.guard.ts
+++ b/src/auth/guard/jwt-auth.guard.ts
@@ -1,5 +1,31 @@
-import {Injectable} from '@nestjs/common';
+import {
+  Injectable,
+  BadRequestException,
+  ServiceUnavailableException,
+  ExecutionContext,
+  Head,
+} from '@nestjs/common';
 import {AuthGuard} from '@nestjs/passport';
+import {Err} from './../../common/error';
 
 @Injectable()
-export class JwtAuthGuard extends AuthGuard('jwt') {}
+export class JwtAuthGuard extends AuthGuard('jwt') {
+  handleRequest(err, user, info) {
+    if (user) {
+      return user;
+    }
+    switch (info.toString()) {
+      case 'Error: No auth token':
+        throw new BadRequestException(Err.TOKEN.NOT_SEND_TOKEN);
+
+      case 'JsonWebTokenError: invalid signature':
+        throw new BadRequestException(Err.TOKEN.INVALID_TOKEN);
+
+      case 'TokenExpiredError: jwt expired':
+        throw new BadRequestException(Err.TOKEN.JWT_EXPIRED);
+
+      default:
+        throw new ServiceUnavailableException(Err.SERVER.UNEXPECTED_ERROR);
+    }
+  }
+}

--- a/src/auth/guard/jwt-refresh.guard.ts
+++ b/src/auth/guard/jwt-refresh.guard.ts
@@ -5,54 +5,37 @@ import {
   ServiceUnavailableException,
 } from '@nestjs/common';
 import {AuthGuard} from '@nestjs/passport';
-import {AuthService} from '../auth.service';
-import {UserService} from './../../user/user.service';
 import {Err} from './../../common/error';
 
 @Injectable()
 export class JwtRefreshGuard extends AuthGuard('jwt-refresh') {
-  constructor(private authService: AuthService, private userService: UserService) {
+  constructor() {
     super();
   }
 
-  async canActivate(context: ExecutionContext) {
-    const request = context.switchToHttp().getRequest();
-    const {authorization} = request.headers;
-
-    if (authorization === undefined) {
-      throw new BadRequestException(Err.TOKEN.NOT_SEND_REFRESH_TOKEN);
-    }
-
-    const refreshToken = authorization.replace('Bearer ', '');
-    const refreshTokenValidate = await this.validate(refreshToken);
-    request.user = refreshTokenValidate;
-    return true;
-  }
-
-  async validate(refreshToken: string) {
-    try {
-      const tokenVerify = await this.authService.tokenValidate(refreshToken);
-      const user = await this.userService.findUserById(tokenVerify.sub);
+  handleRequest(err, user, info, context: ExecutionContext) {
+    if (user) {
+      const {authorization} = context.switchToHttp().getRequest().headers;
+      const refreshToken = authorization.replace('Bearer ', '');
       if (user.refreshToken === refreshToken) {
+        delete user.refreshToken;
         return user;
       } else {
         throw new BadRequestException(Err.TOKEN.NO_PERMISSION);
       }
-    } catch (error) {
-      switch (error.message) {
-        // 토큰에 대한 오류를 판단합니다.
-        case 'invalid token':
-          throw new BadRequestException(Err.TOKEN.INVALID_TOKEN);
+    }
+    switch (info.toString()) {
+      case 'Error: No auth token':
+        throw new BadRequestException(Err.TOKEN.NOT_SEND_TOKEN);
 
-        case 'no permission':
-          throw new BadRequestException(Err.TOKEN.NO_PERMISSION);
+      case 'JsonWebTokenError: invalid signature':
+        throw new BadRequestException(Err.TOKEN.INVALID_TOKEN);
 
-        case 'jwt expired':
-          throw new BadRequestException(Err.TOKEN.JWT_EXPIRED);
+      case 'TokenExpiredError: jwt expired':
+        throw new BadRequestException(Err.TOKEN.JWT_EXPIRED);
 
-        default:
-          throw new ServiceUnavailableException(Err.SERVER.UNEXPECTED_ERROR);
-      }
+      default:
+        throw new ServiceUnavailableException(Err.SERVER.UNEXPECTED_ERROR);
     }
   }
 }

--- a/src/auth/strategy/jwt-refresh.strategy.ts
+++ b/src/auth/strategy/jwt-refresh.strategy.ts
@@ -2,14 +2,21 @@ import {Injectable} from '@nestjs/common';
 import {PassportStrategy} from '@nestjs/passport';
 import {ExtractJwt, Strategy} from 'passport-jwt';
 import {ConfigService} from '@nestjs/config';
+import {UserService} from './../../user/user.service';
 
 @Injectable()
 export class JwtRefreshStrategy extends PassportStrategy(Strategy, 'jwt-refresh') {
-  constructor(config: ConfigService) {
+  constructor(config: ConfigService, private userService: UserService) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
       secretOrKey: config.get('auth').secret,
     });
+  }
+
+  async validate(payload: any) {
+    const user = await this.userService.findUserById(payload.sub);
+    const refreshToken = user.refreshToken;
+    return {id: payload.sub, refreshToken};
   }
 }

--- a/src/common/entity/base-entity.entity.ts
+++ b/src/common/entity/base-entity.entity.ts
@@ -1,7 +1,6 @@
 import {Entity, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn} from 'typeorm';
 import {ApiProperty} from '@nestjs/swagger';
 
-@Entity()
 export class BaseEntity {
   @PrimaryGeneratedColumn()
   @ApiProperty({description: '아이디', example: '1'})

--- a/src/common/error.ts
+++ b/src/common/error.ts
@@ -32,11 +32,11 @@ export const Err = {
     },
     NOT_SEND_REFRESH_TOKEN: {
       code: 401,
-      message: 'Refresh Token 전송이 안 되었습니다.',
+      message: '리프레시 토큰이 전송되지 않았습니다.',
     },
     NOT_SEND_TOKEN: {
       code: 401,
-      message: 'Token 전송이 안 되었습니다.',
+      message: '토큰이 전송되지 않았습니다.',
     },
   },
   VERIFY_CODE: {

--- a/src/user/user.docs.ts
+++ b/src/user/user.docs.ts
@@ -1,5 +1,5 @@
 import {applyDecorators} from '@nestjs/common';
-import {ApiCreatedResponse, ApiOperation, ApiBearerAuth} from '@nestjs/swagger';
+import {ApiCreatedResponse, ApiOperation, ApiBearerAuth, ApiResponse} from '@nestjs/swagger';
 import {UserController} from './user.controller';
 import {SwaggerMethodDoc} from 'src/common/types';
 import {GetProfileResponseBodyDto} from './dto/get-profile.dto';
@@ -14,6 +14,11 @@ export const docs: SwaggerMethodDoc<UserController> = {
       }),
       ApiCreatedResponse({
         type: GetProfileResponseBodyDto,
+      }),
+      ApiResponse({
+        status: 401,
+        description:
+          '1. 토큰이 전송되지 않았습니다. \t\n 2. 유효하지 않은 토큰입니다. \t\n 3. 토큰이 만료되었습니다.',
       }),
     );
   },


### PR DESCRIPTION
## 변경사항

### JwtRefreshGuard
- 기존 guard에서 모든 validation이 이루어지던 로직
- `JwtRefreshStrategy validate`에서 id와 refresh token을 받아서 `JwtRefreshGuard handleRequest`에서 비교하도록 변경

### JwtAuthGuard
- 에러 핸들링 가능하도록 로직 추가

### docs 에러 리스폰스 설명 추가
**api/v1/docs**에서 확인해주세요.
- jwt-auth.guard, jwt-refresh.guard로 보호되고 있는 라우터는 swagger에 ApiBearerAuth() 추가해주세요.

## TODO
- 소현님 작업 시작 해주시면 될 것 같습니다🙇‍♀️